### PR TITLE
Fix Emplaitress occasionally killing Norns CPU

### DIFF
--- a/lib/emplaitress.sc
+++ b/lib/emplaitress.sc
@@ -1,9 +1,11 @@
 Emplaitress {
-    classvar <notes, <inverse, <groups;
+    classvar <notes, <inverse, <groups, <voiceOrder, <maxVoices;
 
     *initClass {
         notes = 6.collect { Dictionary.new};
 		inverse = 6.collect {IdentityDictionary.new};
+		voiceOrder = 6.collect { Array.new };
+		maxVoices = 16;
         
         StartUp.add {
 			(Routine.new {
@@ -96,6 +98,7 @@ Emplaitress {
 					if (notes[voice][curNote] === syn, {
 						notes[voice].removeAt(curNote);
 					});
+					voiceOrder[voice].remove(syn);
 					// "freed %\n".postf(syn.nodeID)
 				});
 	    	    if (notes[voice].includesKey(note), {
@@ -106,6 +109,20 @@ Emplaitress {
 				// 2-way dict bookeeping.
 	    	    notes[voice].put(note, syn);
 				inverse[voice].put(syn, note);
+				voiceOrder[voice] = voiceOrder[voice].add(syn);
+
+				// LRU: prune oldest voices if over limit
+				while ({ voiceOrder[voice].size > maxVoices }, {
+					var oldest = voiceOrder[voice].removeAt(0);
+					var oldNote = inverse[voice][oldest];
+					if (oldNote.notNil, {
+						if (notes[voice][oldNote] === oldest, {
+							notes[voice].removeAt(oldNote);
+						});
+						inverse[voice].removeAt(oldest);
+					});
+					oldest.free;
+				});
 				}).play;
 	    	}, "emplaitress/note_on");
 	    	OSCFunc.new({ |msg, time, addr, recvPort|			
@@ -156,11 +173,26 @@ Emplaitress {
 						if (notes[voice][curNote] === syn, {
 							notes[voice].removeAt(curNote);
 						});
+						voiceOrder[voice].remove(syn);
 					});
 
 					// 2-way dict bookeeping.
 		    	    notes[voice].put(new_note, syn);
 					inverse[voice].put(syn, new_note);
+					voiceOrder[voice] = voiceOrder[voice].add(syn);
+
+					// LRU: prune oldest voices if over limit
+					while ({ voiceOrder[voice].size > maxVoices }, {
+						var oldest = voiceOrder[voice].removeAt(0);
+						var oldNote = inverse[voice][oldest];
+						if (oldNote.notNil, {
+							if (notes[voice][oldNote] === oldest, {
+								notes[voice].removeAt(oldNote);
+							});
+							inverse[voice].removeAt(oldest);
+						});
+						oldest.free;
+					});
 					});
 	    	}, "emplaitress/note_mod");
 

--- a/lib/emplaitress.sc
+++ b/lib/emplaitress.sc
@@ -96,6 +96,7 @@ Emplaitress {
 					if (notes[voice][curNote] === syn, {
 						notes[voice].removeAt(curNote);
 					});
+					// "freed %\n".postf(syn.nodeID)
 				});
 	    	    if (notes[voice].includesKey(note), {
 					var toEnd = notes[voice][note];
@@ -164,11 +165,17 @@ Emplaitress {
 	    	}, "emplaitress/note_mod");
 
 			OSCFunc.new({|msg, time, addr, recvPort|
-				notes.keysValuesDo {|voice, active|
-					active.keysValuesDo {|note, syn|
+				inverse.do {|active, voice|
+					active.keysValuesDo {|syn, note|
 						syn.set(\gate, 0);
-						active.removeAt(note);
-						inverse.removeAt(syn);
+						// active.removeAt(syn); -- this will happen in onFree
+						notes[voice].removeAt(note);
+						SystemClock.sched(1.0, {
+							// some engines get stuck playing forever
+							if (syn.isPlaying, {
+								syn.free;
+							});
+						});
 					};
 				};
 			}, "emplaitress/stop_all");


### PR DESCRIPTION
This does two things:

#### Voice stealing
Now Emplaitress tracks playing synths and eagerly prunes the least recently used if the Norns script plays more than 16 concurrent voices.

This is needed because of two reasons. First off, there's a bug in the Kick engine that causes voices to sometimes never decay completely. Over time this eats CPU without any audible effect. DetectSilence is failing on that one. I suspect denormals, but I ain't debugging the C codebase. Second, it's possible for the user script to sustain notes too long and therefore cause CPU overloads.

This change ensures we never allow runaway polyphony. I set the limit at a generous 16 voices since my tests indicate this should be enough to avoid crackles.

#### /stop_all
Now /stop_all actually stops all notes. The previous implementation went over `notes` with `keysValuesDo`. This is an **array** and in Supercollider this meant **pairwise iteration**, so half of the notes were never cleaned (as that dictionary landed under the `voice` variable). More importantly, going through `notes` only ever freed the last synth to play a given note. If there were other synths still ringing out on the same note, they would never be cleaned. The new implementation therefore goes through the `inverse` array. It sends `\gate, 0` again, but since we wanted to `/stop_all`, after a second if the sounds are still playing, it sends an eager `syn.free` to ensure we leave no hanging notes.

Without this change it was impossible to recover `scsynth` to a usable state without restarting Supercollider.